### PR TITLE
feature/#2 コミットテンプレート設定

### DIFF
--- a/commitSettings/commit-msg.rb
+++ b/commitSettings/commit-msg.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+message_file = ARGV[0]
+message = File.read(message_file, :encoding => Encoding::UTF_8)
+
+current_branch = `git branch | grep '*'`.chomp.sub('* ', '')
+current_branch = current_branch << ' '
+# 該当のprefixで始まるブランチはチケット番号を抜き出す
+#（チケット番号以降がハイフンで句切られていない場合は保証外）
+#（ハイフン以前を抜き出すので、ハイフンがなければ置き換えなし）
+check_bugfix = current_branch.include?("bugfix/")
+check_feature = current_branch.include?("feature/")
+check_refactor = current_branch.include?("refactor/")
+if check_bugfix || check_feature || check_refactor then
+  check_github = current_branch.include?("#")
+  if check_github then
+    split_strings = current_branch.split("-", 2)
+    if split_strings.length >= 2 then
+      current_branch = split_strings[0] << ' '
+    end
+  else
+    split_strings = current_branch.split("-", 3)
+    if split_strings.length >= 3 then
+      current_branch = split_strings[0] << '-' << split_strings[1] << ' '
+    end
+  end
+end
+new_message = message.sub(/\[issue\]/, current_branch)
+
+File.write(message_file, new_message)

--- a/commitSettings/commitTemplate.txt
+++ b/commitSettings/commitTemplate.txt
@@ -1,0 +1,6 @@
+[issue]
+
+■ Overview
+
+■ Test procedure
+

--- a/commitSettings/removesCommitSettings.sh
+++ b/commitSettings/removesCommitSettings.sh
@@ -1,0 +1,5 @@
+rootDir=`git rev-parse --show-toplevel`
+cd $rootDir
+
+git config --unset commit.template
+rm .git/hooks/commit-msg

--- a/commitSettings/updatesCommitSettings.sh
+++ b/commitSettings/updatesCommitSettings.sh
@@ -1,0 +1,7 @@
+rootDir=`git rev-parse --show-toplevel`
+cd $rootDir
+git config commit.template $rootDir/CommitSettings/commitTemplate.txt
+
+mkdir -p .git/hooks
+cp $rootDir/CommitSettings/commit-msg.rb $rootDir/.git/hooks/commit-msg
+chmod +x $rootDir/.git/hooks/commit-msg


### PR DESCRIPTION
■ Overview
bugfix、feature、refactorがprefixのブランチ名の場合、[issue]をfeature/#2などのチケット番号までを抜き出す処理を実装
git commit時にhookして置換
sh commitSettings/updatesCommitSettings.shで適用